### PR TITLE
created karate equivalent

### DIFF
--- a/java/karate/README.md
+++ b/java/karate/README.md
@@ -1,0 +1,3 @@
+# Java
+
+Requires Java and Maven.  To run simply clone the repo down and run ```mvn test```

--- a/java/karate/pom.xml
+++ b/java/karate/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.restfulbooker.api</groupId>
+    <artifactId>api-checks</artifactId>
+    <version>1.0-SNAPSHOT</version>        
+
+    <dependencies>
+		<dependency>
+			<groupId>com.intuit.karate</groupId>
+			<artifactId>karate-apache</artifactId>
+			<version>0.4.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.intuit.karate</groupId>
+			<artifactId>karate-junit4</artifactId>
+			<version>0.4.1</version>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
+    
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>                       
+        </plugins>        
+    </build>    
+
+</project>

--- a/java/karate/src/test/java/karate-config.js
+++ b/java/karate/src/test/java/karate-config.js
@@ -1,0 +1,3 @@
+function() {
+  return {};
+}

--- a/java/karate/src/test/java/logback-test.xml
+++ b/java/karate/src/test/java/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+ 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+  
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/karate.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>    
+   
+    <logger name="com.intuit" level="DEBUG"/>
+   
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+  
+</configuration>

--- a/java/karate/src/test/java/restfulbooker/ApiTest.java
+++ b/java/karate/src/test/java/restfulbooker/ApiTest.java
@@ -1,0 +1,11 @@
+package restfulbooker;
+
+import com.intuit.karate.junit4.Karate;
+import cucumber.api.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@CucumberOptions(plugin = {"pretty", "html:target/cucumber"})
+public class ApiTest {
+    
+}

--- a/java/karate/src/test/java/restfulbooker/api-test.feature
+++ b/java/karate/src/test/java/restfulbooker/api-test.feature
@@ -1,0 +1,51 @@
+Feature: restful-booker api test demo
+
+Background: 
+* url 'http://localhost:3001'
+* header Accept = 'application/json'
+* def date = read('new-date.js')
+* def payload = 
+"""
+{ 
+  firstname: 'Mary', lastname: 'White', totalprice: 200, depositpaid: true,
+  bookingdates: { checkin: '#(date())', checkout: '#(date())' }
+}
+"""
+
+Scenario: get booking should return 200
+  Given path 'booking'
+  When method get
+  Then status 200
+  # not supported by rest-assured
+  And match each response == { bookingid: '#number' }
+
+Scenario: get booking by id should return 200
+  Given path 'booking', 1  
+  When method get
+  Then status 200
+
+Scenario: get booking by id with bad accept header should return 418
+  Given path 'booking', 1
+  And header Accept = 'text/plain'
+  When method get
+  Then status 418
+
+Scenario: post booking returns 200 and delete booking returns 201
+  Given path 'booking'
+  And request payload
+  When method post
+  Then status 200
+  # not supported by rest-assured
+  And match response.booking == payload
+  And def bookingId = response.bookingid
+
+  Given path 'auth'
+  And request { username: 'admin', password: 'password123' }
+  When method post
+  Then status 200
+  And def authToken = response.token
+
+  Given path 'booking', bookingId
+  And header Cookie = 'token=' + authToken
+  When method delete
+  Then status 201

--- a/java/karate/src/test/java/restfulbooker/new-date.js
+++ b/java/karate/src/test/java/restfulbooker/new-date.js
@@ -1,0 +1,5 @@
+function() {
+  var sm = new java.text.SimpleDateFormat("yyyy-MM-dd");
+  var date = new java.util.Date();
+  return sm.format(date);
+}


### PR DESCRIPTION
Mark: I've added the [Karate](https://github.com/intuit/karate) equivalent of the tests.

This took me less than an hour to implement.  A few things I'd l like to call out (especially comparing this with REST-assured):
- no need to define request or response payload Java (POJO) objects
- in fact the data is expressed 'in-line', and the test is much more readable
- no need to create 'page object' representations of end-points as the HTTP operations boil down to one-liners
- lines 20, 39 and 40 in `api-test.feature` are proper validations (and access to data) you cannot do easily in REST-assured

I'd like to point you to this detailed comparison of Karate vs REST-assured: http://tinyurl.com/karatera - for your reference.

Hope you can add this to your project and blog / tweet about it !! Thanks for your time.

<img width="1286" alt="karate-vs-rest-assured" src="https://user-images.githubusercontent.com/915480/26962447-cea454f4-4d03-11e7-9057-ec2aa8eab74b.png">

